### PR TITLE
add pkg-config installation to the script

### DIFF
--- a/recorded/capivara/scripts/v8-env-script-x86.sh
+++ b/recorded/capivara/scripts/v8-env-script-x86.sh
@@ -1,5 +1,6 @@
 sudo apt-get install -y ccache
 sudo apt-get install -y cmake
+sudo apt-get install -y pkg-config
 
 ccache --version 
 # ccache version 4.6.3
@@ -12,6 +13,9 @@ ccache g++ --version
 
 cmake --version
 # cmake version 3.24.1
+
+pkg-config --version
+# 0.29.2
 
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 export PATH=`pwd`/depot_tools:$PATH


### PR DESCRIPTION
In my environment, there was no pkg-config installed. It was making the tools/dev/v8gen.py x64.release.sample line to throw an error.
After investigation, I discovered that the script build/config/linux/pkg-config.py relies on pkg-config (line 80) to define some parameters and due to lack of the pkg-config, it has broken the execution.

System info:
- Hardware model: Dell Inc. Latitude 5400
- Processor: Intel® Core™ i5-8265U CPU @ 1.60GHz × 8
- OS Name: Ubuntu 22.04.2 LTS
- OS Type: 64-bit